### PR TITLE
Update AndroidManifest and build.gradle for namespace configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'io.flutterfastkit.fk_user_agent'
+
     compileSdkVersion 30
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutterfastkit.fk_user_agent">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
### Description
This branch addresses the build failure issue caused by the missing `namespace` property in the `build.gradle` file of the `fk_user_agent` module. The `namespace` property is required by the newer versions of the Android Gradle Plugin (AGP) to uniquely identify the package namespace for the module.

### Changes
- Added the `namespace` property to the `build.gradle` file of the `fk_user_agent` module to match the `package` attribute in the `AndroidManifest.xml`.
